### PR TITLE
patch/dynamic-policy-creation: Fixing for_each dependency issue

### DIFF
--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -100,9 +100,9 @@ resource "aws_iam_role_policy_attachment" "init_script_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "user_policies" {
-  for_each   = toset(var.iam_policies)
+  count   = length(var.iam_policies)
   role       = aws_iam_role.sidecar_role.name
-  policy_arn = each.value
+  policy_arn = var.iam_policies[count.index]
 }
 
 ##############################


### PR DESCRIPTION
Reverted for_each iteration over list back to count/indexing, due to for_each limitation requiring data to be known before module run.

This becomes an issue if you are nesting this module into a parent module. In the parent module you are creating necessary IAM policies for a particular purpose. In my case I have dedicated sidecars for MongoDB Atlas and S3, and each of those sidecar deployments require specific policies. In a parent terraform module I have other infrastructure being created to support this deployment + IAM policies for the previously stated sidecar functions. If I pass the output arn of the created policies to `var.iam_policies` the following error gets thrown:

` The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will
│ be created.`

This patch seems to fix the issue.